### PR TITLE
call command with all arguments, not just the first one

### DIFF
--- a/usage-wrapper.py
+++ b/usage-wrapper.py
@@ -346,8 +346,10 @@ if args.verbose:
 
 cp = None
 try:
-    cmd = args.command1 if args.command1 else args.command
-    cp = subprocess.run(cmd, shell=True)
+    if args.command1:
+        cp = subprocess.run(args.command1, shell=True)
+    else:
+        cp = subprocess.run(args.command)
 except KeyboardInterrupt:
     rv = 2
 finally:


### PR DESCRIPTION
args.command is an array with the split command line. Don't pass just the command without parameters. And no need to set shell=True, the command is already parsed. An alternative could be to call shlex.join on args.command. But what happens with quoting then?
